### PR TITLE
feat: Create settings UI Interface

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -45,6 +45,13 @@ const createTables = (db: sqlite3.Database) => {
         FOREIGN KEY (patient_id) REFERENCES Patients (id)
       );
     `);
+
+    db.run(`
+      CREATE TABLE IF NOT EXISTS Settings (
+        key TEXT PRIMARY KEY,
+        value TEXT
+      );
+    `);
   });
 };
 
@@ -92,6 +99,42 @@ export const createPatient = (patient: { id: string; name: string; dob: string; 
         }
       }
     );
+  });
+};
+
+export const getSettings = (): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    const db = getDb();
+    db.all('SELECT * FROM Settings', (err, rows) => {
+      if (err) {
+        reject(err);
+      } else {
+        const settings = rows.reduce((acc, row) => {
+          acc[row.key] = row.value;
+          return acc;
+        }, {});
+        resolve(settings);
+      }
+    });
+  });
+};
+
+export const setSettings = (settings: any): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const db = getDb();
+    db.serialize(() => {
+      const stmt = db.prepare('INSERT OR REPLACE INTO Settings (key, value) VALUES (?, ?)');
+      for (const key in settings) {
+        stmt.run(key, settings[key]);
+      }
+      stmt.finalize((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 };
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import path from 'path';
-import { initializeDatabase, getDb, getAllPatients } from './database';
+import { initializeDatabase, getDb, getAllPatients, getSettings, setSettings } from './database';
 import { initializeWatcher } from './watcher';
 import { seedDatabase } from './seed';
 
@@ -55,6 +55,25 @@ ipcMain.handle('get-all-patients', async (event, filters) => {
     return patients;
   } catch (error) {
     console.error('Failed to get all patients:', error);
+    throw error;
+  }
+});
+
+ipcMain.handle('get-settings', async () => {
+  try {
+    const settings = await getSettings();
+    return settings;
+  } catch (error) {
+    console.error('Failed to get settings:', error);
+    throw error;
+  }
+});
+
+ipcMain.handle('set-settings', async (event, settings) => {
+  try {
+    await setSettings(settings);
+  } catch (error) {
+    console.error('Failed to set settings:', error);
     throw error;
   }
 });

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -2,4 +2,6 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getAllPatients: (filters: any) => ipcRenderer.invoke('get-all-patients', filters),
+  getSettings: () => ipcRenderer.invoke('get-settings'),
+  setSettings: (settings: any) => ipcRenderer.invoke('set-settings', settings),
 });

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1,7 +1,27 @@
 <script lang="ts">
   import PatientDashboard from './PatientDashboard.svelte';
+  import Settings from './Settings.svelte';
+  import { currentView } from './stores';
 </script>
 
 <main>
-  <PatientDashboard />
+  <nav>
+    <button on:click={() => currentView.set('dashboard')}>Dashboard</button>
+    <button on:click={() => currentView.set('settings')}>Settings</button>
+  </nav>
+
+  {#if $currentView === 'dashboard'}
+    <PatientDashboard />
+  {:else if $currentView === 'settings'}
+    <Settings />
+  {/if}
 </main>
+
+<style>
+  nav {
+    display: flex;
+    gap: 1em;
+    padding: 1em;
+    border-bottom: 1px solid #ddd;
+  }
+</style>

--- a/src/renderer/Settings.svelte
+++ b/src/renderer/Settings.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  let settings = {
+    someSetting: '',
+    anotherSetting: '',
+  };
+
+  onMount(async () => {
+    try {
+      const fetchedSettings = await window.electronAPI.getSettings();
+      if (fetchedSettings) {
+        settings = { ...settings, ...fetchedSettings };
+      }
+    } catch (error) {
+      console.error('Error fetching settings:', error);
+    }
+  });
+
+  async function saveSettings() {
+    try {
+      await window.electronAPI.setSettings(settings);
+      alert('Settings saved successfully!');
+    } catch (error) {
+      console.error('Error saving settings:', error);
+      alert('Failed to save settings.');
+    }
+  }
+</script>
+
+<main>
+  <h1>Settings</h1>
+
+  <form on:submit|preventDefault={saveSettings}>
+    <div class="form-group">
+      <label for="some-setting">Some Setting:</label>
+      <input id="some-setting" type="text" bind:value={settings.someSetting} />
+    </div>
+
+    <div class="form-group">
+      <label for="another-setting">Another Setting:</label>
+      <input id="another-setting" type="text" bind:value={settings.anotherSetting} />
+    </div>
+
+    <button type="submit">Save</button>
+  </form>
+</main>
+
+<style>
+  main {
+    padding: 1em;
+  }
+  .form-group {
+    margin-bottom: 1em;
+  }
+  label {
+    display: block;
+    margin-bottom: 0.5em;
+  }
+  input {
+    width: 100%;
+    padding: 0.5em;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+  }
+</style>

--- a/src/renderer/stores.ts
+++ b/src/renderer/stores.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const currentView = writable('dashboard');


### PR DESCRIPTION
This commit introduces a new settings UI to the application.

It includes:
- A new `Settings` table in the database.
- `getSettings` and `setSettings` functions in `database.ts`.
- IPC handlers for `get-settings` and `set-settings`.
- A new `Settings.svelte` component.
- A Svelte store for managing the current view.
- Updates to `App.svelte` to allow navigation between the dashboard and settings pages.