### PR TITLE
feat: Define unified report structure

### DIFF
--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -1,6 +1,7 @@
 import pdf from 'pdf-parse';
 import { createWorker } from 'tesseract.js';
 import * as fs from 'fs';
+import { UnifiedReport } from './reports';
 
 /**
  * Extracts text from a PDF file, using OCR as a fallback.
@@ -31,16 +32,34 @@ export const extractTextFromPdf = async (filePath: string): Promise<string> => {
  * This is a placeholder for manufacturer-specific parsing logic.
  *
  * @param text The raw text from the PDF.
- * @returns A structured data object (currently, a placeholder).
+ * @returns A structured data object conforming to the UnifiedReport interface.
  */
-export const extractStructuredData = (text: string) => {
+export const extractStructuredData = (text: string): UnifiedReport => {
   console.log('Extracting structured data from text...');
-  // Placeholder for future manufacturer-specific parsing logic
-  return {
-    rawText: text.substring(0, 500) + '...', // Return a snippet for now
+
+  // This is a placeholder implementation. In a real scenario, this function
+  // would contain complex logic to parse the text and populate the fields.
+  const placeholderReport: UnifiedReport = {
     manufacturer: 'Unknown',
-    // ... other structured fields will go here
+    interrogation_date: new Date().toISOString().split('T')[0], // Today's date as a placeholder
+    patient: {
+      first_name: 'Unknown',
+      last_name: 'Unknown',
+      dob: '1900-01-01', // Placeholder DOB
+    },
+    device: {
+      type: 'Unknown',
+      model: 'Unknown',
+      serial_number: 'Unknown',
+    },
+    battery: {
+      // Empty placeholder
+    },
+    leads: [], // Default to an empty array
+    raw_text: text, // Store the full raw text
   };
+
+  return placeholderReport;
 };
 
 

--- a/src/main/reports.ts
+++ b/src/main/reports.ts
@@ -1,0 +1,70 @@
+// src/main/reports.ts
+
+/**
+ * A single measurement with a value and its unit.
+ */
+export interface Measurement {
+  value: number | string;
+  unit: string;
+}
+
+/**
+ * Represents a single component, like a lead. Includes its own implant date.
+ */
+export interface LeadData {
+  name: string;
+  anatomic_location?: string;
+  implant_date?: string; // ADDED: ISO 8601 format for individual lead implant date
+  pacing_threshold?: Measurement;
+  sensing?: Measurement;
+  impedance?: Measurement;
+}
+
+/**
+ * Represents the device's battery status.
+ */
+export interface BatteryData {
+  voltage?: Measurement;
+  remaining_longevity?: Measurement;
+  status?: 'OK' | 'ERI' | 'EOL' | string;
+}
+
+/**
+ * The top-level, standardized structure for a parsed interrogation report.
+ */
+export interface UnifiedReport {
+  // --- Metadata (from the report and the hospital system) ---
+  manufacturer: 'Medtronic' | 'Biotronik' | 'Abbott' | 'Boston Scientific' | 'Impulse Dynamics' | 'Microport' | 'Unknown' | string;
+  interrogation_date: string; // ISO 8601 format
+  hospital_visit_id?: string; // ADDED: The hospital's identifier for this specific visit/encounter.
+
+  // --- Patient Identification ---
+  patient: {
+    first_name: string; // ADDED: More granular name fields
+    last_name: string;  // ADDED
+    dob: string;        // RENAMED for clarity (Date of Birth in ISO 8601 format)
+    hospital_patient_id?: string; // ADDED: The patient's permanent ID in the hospital system (e.g., MRN)
+  };
+
+  // --- Device & System Identification ---
+  device: {
+    type: 'Pacemaker' | 'ICD' | 'S-ICD' | 'Leadless Pacemaker' | 'CCM' | 'Unknown' | string;
+    model: string;
+    serial_number: string;
+    implant_date?: string; // ISO 8601 format for the primary device implant date
+  };
+
+  // --- Core Clinical Data ---
+  battery: BatteryData;
+  leads?: LeadData[];
+
+  // --- Key Findings & Summaries ---
+  arrhythmia_summary?: {
+    atrial_fibrillation_burden?: Measurement;
+    ventricular_tachycardia_episodes?: number;
+    [key: string]: any;
+  };
+
+  // --- Raw Data ---
+  raw_text: string;
+}


### PR DESCRIPTION
Introduces a new file, src/main/reports.ts, to define a standardized TypeScript interface for IECD interrogation reports.

The UnifiedReport interface is designed to be flexible and accommodate various manufacturers, device types (including leadless and S-ICD), and complex clinical data.

Updates the extractStructuredData function in src/main/parser.ts to use the new UnifiedReport interface as its return type, ensuring type safety in the parsing pipeline.