### PR TITLE
feat: Integrate Biotronik XML parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/pdf-parse": "^1.1.5",
         "@types/uuid": "^10.0.0",
+        "fast-xml-parser": "^5.3.1",
         "pdf-parse": "^2.4.5",
         "tesseract.js": "^6.0.1",
         "uuid": "^13.0.0"
@@ -3936,6 +3937,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.1.tgz",
+      "integrity": "sha512-jbNkWiv2Ec1A7wuuxk0br0d0aTMUtQ4IkL+l/i1r9PRf6pLXjDgsBsWwO+UyczmQlnehi4Tbc8/KIvxGQe+I/A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -6676,6 +6695,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@types/pdf-parse": "^1.1.5",
     "@types/uuid": "^10.0.0",
+    "fast-xml-parser": "^5.3.1",
     "pdf-parse": "^2.4.5",
     "tesseract.js": "^6.0.1",
     "uuid": "^13.0.0"

--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -1,7 +1,9 @@
 import pdf from 'pdf-parse';
 import { createWorker } from 'tesseract.js';
 import * as fs from 'fs';
+import * as path from 'path';
 import { UnifiedReport } from './reports';
+import { parseBiotronikXML } from './parsers/biotronik-parser';
 
 /**
  * Extracts text from a PDF file, using OCR as a fallback.
@@ -64,9 +66,19 @@ export const extractStructuredData = (text: string): UnifiedReport => {
 
 
 // This module will be responsible for parsing the proprietary text files.
-export const parseFile = async (filename: string) => {
-  console.log(`Parsing file: ${filename}`);
-  const rawText = await extractTextFromPdf(filename);
-  const structuredData = extractStructuredData(rawText);
-  return structuredData;
+export const parseFile = async (filePath: string): Promise<UnifiedReport | null> => {
+  console.log(`Parsing file: ${filePath}`);
+  const fileExtension = path.extname(filePath).toLowerCase();
+  const filename = path.basename(filePath);
+
+  if (fileExtension === '.pdf') {
+    const rawText = await extractTextFromPdf(filePath);
+    return extractStructuredData(rawText);
+  } else if (fileExtension === '.xml' && filename.startsWith('BIOSTD_')) {
+    const xmlData = fs.readFileSync(filePath, 'utf-8');
+    return parseBiotronikXML(xmlData);
+  } else {
+    console.warn(`Unsupported file type: ${fileExtension}`);
+    return null;
+  }
 };

--- a/src/main/parsers/biotronik-parser.ts
+++ b/src/main/parsers/biotronik-parser.ts
@@ -1,0 +1,160 @@
+// src/main/parsers/biotronik-parser.ts
+
+import { XMLParser } from 'fast-xml-parser';
+import { UnifiedReport, LeadData, BatteryData, Measurement } from '../reports';
+
+/**
+* --- Biotronik XML Parser ---
+* * This file reads the proprietary Biotronik XML export and transforms
+* it into our internal, standardized JSON format.
+* * ~<*>~
+*/
+
+// --- Helper Functions to navigate the complex XML structure ---
+
+/**
+* Finds a specific
+*/
+function findTable(data: any, tableName: string): any[] | null {
+try {
+const tables = data['carddas:InterfaceData']['carddas:Examination']['carddas:Measurements']['carddas:Table'];
+for (const table of tables) {
+if (table['carddas:TableName'] === tableName) {
+return table['carddas:TableEntry'];
+}
+}
+} catch (e) {
+console.error(`Error finding table: ${tableName}`, e);
+}
+return null;
+}
+
+/**
+* Finds a value from a
+* E.g., findTableEntry(table, 'SERHSM') -> '88763967'
+*/
+function findEntry(tableEntries: any[], attributeName: string): string | null {
+if (!tableEntries) return null;
+try {
+const entry = tableEntries.find(e => e['carddas:AttributeName'] === attributeName);
+if (!entry) return null;
+
+if (entry['carddas:CharValue']) return entry['carddas:CharValue'];
+if (entry['carddas:DecimalValue']) return entry['carddas:DecimalValue'].toString();
+if (entry['carddas:SmallIntValue']) return entry['carddas:SmallIntValue'].toString();
+if (entry['carddas:DateValue']) return entry['carddas:DateValue'];
+
+} catch (e) {
+console.error(`Error finding attribute: ${attributeName}`, e);
+}
+return null;
+}
+
+/**
+* The main parser function.
+* @param xmlData The raw XML string content from the .xml file.
+* @returns Our standardized JSON object, or null if parsing fails.
+*/
+export function parseBiotronikXML(xmlData: string): UnifiedReport | null {
+try {
+const parser = new XMLParser();
+const xml = parser.parse(xmlData);
+
+// Get the two main data tables
+const summaryTable = findTable(xml, 'TBU_DEFI_DATA');
+const settingsTable = findTable(xml, '9002'); // Contains programmed settings
+const statsTable = findTable(xml, '9473'); // Contains arrhythmia stats
+
+// Count 'nsT' episodes from the episode list
+const episodeList = xml['carddas:InterfaceData']['carddas:Examination']['carddas:Measurements']['carddas:Table'].find((t: any) => t['carddas:TableName'] === 'TBU_EPISODE_LIST')['carddas:ForeignKey'];
+const nsTCount = episodeList.filter((ep: any) => ep['carddas:TableEntry'].find((e:any) => e['carddas:CharValue'] === 'nsT')).length;
+
+// --- Assemble the final standardized object ---
+const standardizedData: UnifiedReport = {
+manufacturer: findEntry(summaryTable, 'MANUFACTURERDESCR') || 'Biotronik',
+interrogation_date: xml['carddas:InterfaceData']['carddas:Examination']['carddas:ExaminationDate'],
+patient: {
+first_name: findEntry(summaryTable, 'VORNAME') || '',
+last_name: findEntry(summaryTable, 'NAME') || '',
+dob: findEntry(summaryTable, 'GEBURTSDATUM') || '',
+},
+device: {
+type: 'Unknown', // This information doesn't seem to be in the provided XML structure
+model: findEntry(summaryTable, 'CATAGGREGATDESCR') || '',
+serial_number: findEntry(summaryTable, 'SERHSM') || '',
+},
+battery: {
+voltage: {
+value: findEntry(summaryTable, 'ACTBATTERYVOLTAGE') || '',
+unit: 'V'
+},
+remaining_longevity: {
+value: findEntry(settingsTable, 'Batterie-Restkapazität') || '',
+unit: '%'
+},
+status: findEntry(summaryTable, 'FU1BATTERYSTATUS') || 'Unknown',
+},
+leads: [
+{
+name: 'A-Lead (RA)',
+pacing_threshold: {
+value: `${findEntry(summaryTable, 'A_AMPLITUDE')} @ ${findEntry(summaryTable, 'A_IMPDAUER')}`,
+unit: 'V @ ms'
+},
+sensing: {
+value: findEntry(summaryTable, 'FU_RA_SENSING') || '',
+unit: 'mV'
+},
+impedance: {
+value: findEntry(summaryTable, 'FU_RA_IMPED') || '',
+unit: 'Ohms'
+},
+},
+{
+name: 'V-Lead (RV)',
+pacing_threshold: {
+value: `${findEntry(summaryTable, 'V_AMPLITUDE')} @ ${findEntry(summaryTable, 'V_IMPDAUER')}`,
+unit: 'V @ ms'
+},
+sensing: {
+value: findEntry(summaryTable, 'FU_RV_SENSING') || '',
+unit: 'mV'
+},
+impedance: {
+value: findEntry(summaryTable, 'FU_RV_IMPED') || '',
+unit: 'Ohms'
+},
+},
+{
+name: 'LV-Lead (LV)',
+pacing_threshold: {
+value: `${findEntry(summaryTable, 'LV_AMPLITUDE')} @ ${findEntry(summaryTable, 'LV_IMPDAUER')}`,
+unit: 'V @ ms'
+},
+sensing: {
+value: findEntry(summaryTable, 'FU_LV_SENSING') || '',
+unit: 'mV'
+},
+impedance: {
+value: findEntry(summaryTable, 'FU_LV_IMPED') || '',
+unit: 'Ohms'
+},
+}
+],
+arrhythmia_summary: {
+atrial_fibrillation_burden: {
+value: findEntry(statsTable, 'Atriale Arrhythmielast') || '',
+unit: '%'
+},
+ventricular_tachycardia_episodes: nsTCount,
+},
+raw_text: xmlData,
+};
+
+return standardizedData;
+
+} catch (error) {
+console.error("Failed to parse Biotronik XML:", error);
+return null;
+}
+}


### PR DESCRIPTION
This commit introduces a new parser for Biotronik XML files, adapting the user-provided code to the application's `UnifiedReport` interface.

Key changes include:
- Creating a `src/main/parsers` directory for manufacturer-specific parsers.
- Adding the `fast-xml-parser` dependency to handle XML parsing.
- Implementing the Biotronik parser at `src/main/parsers/biotronik-parser.ts`, ensuring its output conforms to the standardized `UnifiedReport` structure.
- Updating `src/main/parser.ts` to route XML files with filenames starting with `BIOSTD_` to the new Biotronik parser, while maintaining existing PDF processing capabilities.