### PR TITLE
feat: Implemented Boston Scientific parser and PDF merging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/pdf-parse": "^1.1.5",
         "@types/uuid": "^10.0.0",
         "fast-xml-parser": "^5.3.1",
+        "pdf-lib": "^1.17.1",
         "pdf-parse": "^2.4.5",
         "tesseract.js": "^6.0.1",
         "uuid": "^13.0.0"
@@ -1538,6 +1539,24 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -5760,6 +5779,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -5812,6 +5837,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
       }
     },
     "node_modules/pdf-parse": {
@@ -7056,6 +7093,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/pdf-parse": "^1.1.5",
     "@types/uuid": "^10.0.0",
     "fast-xml-parser": "^5.3.1",
+    "pdf-lib": "^1.17.1",
     "pdf-parse": "^2.4.5",
     "tesseract.js": "^6.0.1",
     "uuid": "^13.0.0"

--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { UnifiedReport } from './reports';
 import { parseBiotronikXML } from './parsers/biotronik-parser';
+import { parseBostonScientificBnk } from './parsers/boston-scientific-parser';
 
 /**
  * Extracts text from a PDF file, using OCR as a fallback.
@@ -77,6 +78,9 @@ export const parseFile = async (filePath: string): Promise<UnifiedReport | null>
   } else if (fileExtension === '.xml' && filename.startsWith('BIOSTD_')) {
     const xmlData = fs.readFileSync(filePath, 'utf-8');
     return parseBiotronikXML(xmlData);
+  } else if (fileExtension === '.bnk') {
+    const bnkData = fs.readFileSync(filePath, 'utf-8');
+    return parseBostonScientificBnk(bnkData);
   } else {
     console.warn(`Unsupported file type: ${fileExtension}`);
     return null;

--- a/src/main/parsers/boston-scientific-parser.ts
+++ b/src/main/parsers/boston-scientific-parser.ts
@@ -1,0 +1,72 @@
+// src/main/parsers/boston-scientific-parser.ts
+
+import { UnifiedReport, LeadData, BatteryData, Measurement } from '../reports';
+
+/**
+* --- Boston Scientific BNK Parser ---
+* * This file reads the proprietary Boston Scientific BNK export and transforms
+* it into our internal, standardized JSON format.
+* * ~<*>~
+*/
+
+/**
+* The main parser function.
+* @param bnkData The raw string content from the .bnk file.
+* @returns Our standardized JSON object, or null if parsing fails.
+*/
+export function parseBostonScientificBnk(bnkData: string): UnifiedReport | null {
+  try {
+    const dataMap = new Map<string, string>();
+    const lines = bnkData.split(/\r?\n/);
+
+    for (const line of lines) {
+      const trimmedLine = line.trim();
+      if (trimmedLine.startsWith('#') || trimmedLine.length === 0) {
+        continue;
+      }
+
+      const commaIndex = trimmedLine.indexOf(',');
+      if (commaIndex === -1) {
+        continue;
+      }
+
+      const key = trimmedLine.substring(0, commaIndex).trim();
+      const value = trimmedLine.substring(commaIndex + 1).trim();
+      dataMap.set(key, value);
+    }
+
+    const report: UnifiedReport = {
+        manufacturer: 'Boston Scientific',
+        interrogation_date: dataMap.get('Brady.LastInterrogationDate') || new Date().toISOString().split('T')[0],
+        patient: {
+            first_name: dataMap.get('Patient.PatientFirstName') || '',
+            last_name: dataMap.get('Patient.PatientLastName') || '',
+            dob: dataMap.get('Patient.PatientDOB') || '',
+        },
+        device: {
+            type: 'Unknown',
+            model: dataMap.get('Device.Model') || '',
+            serial_number: dataMap.get('Device.SerialNumber') || '',
+            implant_date: dataMap.get('Device.ImplantDate') || '',
+        },
+        battery: {
+            voltage: {
+                value: dataMap.get('BatteryStatus.BatteryVoltage') || '',
+                unit: 'V',
+            },
+            remaining_longevity: {
+                value: dataMap.get('BatteryStatus.EstLongevity') || '',
+                unit: 'months',
+            },
+            status: dataMap.get('BatteryStatus.BatteryPhase') || 'Unknown',
+        },
+        leads: [], // Lead information is not typically in the BNK file
+        raw_text: bnkData,
+    };
+
+    return report;
+  } catch (error) {
+    console.error("Failed to parse Boston Scientific BNK file:", error);
+    return null;
+  }
+}

--- a/src/main/pdf-merger.ts
+++ b/src/main/pdf-merger.ts
@@ -1,0 +1,50 @@
+// src/main/pdf-merger.ts
+
+import { PDFDocument } from 'pdf-lib';
+import * as fs from 'fs';
+import pdf from 'pdf-parse';
+
+/**
+ * Extracts text from a PDF file.
+ *
+ * @param filePath The path to the PDF file.
+ * @returns A promise that resolves with the extracted text.
+ */
+export const extractTextFromPdf = async (filePath: string): Promise<string> => {
+    const dataBuffer = fs.readFileSync(filePath);
+    const data = await pdf(dataBuffer);
+    return data.text;
+};
+
+/**
+ * Verifies that a PDF belongs to the correct patient.
+ *
+ * @param pdfText The text extracted from the PDF.
+ * @param patientFirstName The patient's first name.
+ * @param patientLastName The patient's last name.
+ * @returns A boolean indicating whether the PDF is verified.
+ */
+export const verifyPdf = (pdfText: string, patientFirstName: string, patientLastName: string): boolean => {
+    // This is a simple verification logic. In a real scenario, this would be more robust.
+    return pdfText.includes(patientFirstName) && pdfText.includes(patientLastName);
+};
+
+
+/**
+ * Merges multiple PDF files into a single PDF.
+ *
+ * @param filePaths An array of paths to the PDF files to merge.
+ * @returns A promise that resolves with the merged PDF as a Uint8Array.
+ */
+export const mergePdfs = async (filePaths: string[]): Promise<Uint8Array> => {
+  const mergedPdf = await PDFDocument.create();
+  for (const filePath of filePaths) {
+    const pdfBytes = fs.readFileSync(filePath);
+    const pdfDoc = await PDFDocument.load(pdfBytes);
+    const copiedPages = await mergedPdf.copyPages(pdfDoc, pdfDoc.getPageIndices());
+    copiedPages.forEach((page) => {
+      mergedPdf.addPage(page);
+    });
+  }
+  return await mergedPdf.save();
+};

--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -1,9 +1,61 @@
 import { parseFile } from './parser';
+import { mergePdfs, extractTextFromPdf, verifyPdf } from './pdf-merger';
+import * as fs from 'fs';
+import * as path from 'path';
+import { UnifiedReport } from './reports';
 
 // This module will be responsible for grouping files that belong to a single "Visit".
-export const routeFiles = async (filename: string) => {
-  console.log(`Routing file: ${filename}`);
-  const data = await parseFile(filename);
-  console.log('Parsed data:', data);
-  // In the future, this is where we'll group files and save to the database.
+export const routeFiles = async (directoryPath: string) => {
+  console.log(`Routing files in directory: ${directoryPath}`);
+
+  const files = fs.readdirSync(directoryPath);
+  const bnkFile = files.find(file => path.extname(file).toLowerCase() === '.bnk');
+  const pdfFiles = files.filter(file => path.extname(file).toLowerCase() === '.pdf');
+
+  if (bnkFile && pdfFiles.length > 0) {
+    // Parse the BNK file first to get patient information
+    const bnkData = await parseFile(path.join(directoryPath, bnkFile));
+
+    if (!bnkData) {
+        console.error(`Failed to parse BNK file: ${bnkFile}`);
+        return;
+    }
+
+    // Verify each PDF
+    const verifiedPdfPaths = [];
+    for (const pdfFile of pdfFiles) {
+        const pdfPath = path.join(directoryPath, pdfFile);
+        const pdfText = await extractTextFromPdf(pdfPath);
+        if (verifyPdf(pdfText, bnkData.patient.first_name, bnkData.patient.last_name)) {
+            verifiedPdfPaths.push(pdfPath);
+        } else {
+            console.warn(`PDF file ${pdfFile} does not seem to belong to patient ${bnkData.patient.first_name} ${bnkData.patient.last_name}.`);
+        }
+    }
+
+    if (verifiedPdfPaths.length === 0) {
+        console.error(`No verified PDFs found for patient ${bnkData.patient.first_name} ${bnkData.patient.last_name}.`);
+        return;
+    }
+
+    // Merge verified PDFs
+    const mergedPdf = await mergePdfs(verifiedPdfPaths);
+    const mergedPdfPath = path.join(directoryPath, 'merged.pdf');
+    fs.writeFileSync(mergedPdfPath, mergedPdf);
+
+    // Parse the merged PDF
+    const pdfData = await parseFile(mergedPdfPath);
+
+    // Combine the data from the BNK file and the merged PDF
+    const combinedData: UnifiedReport = {
+        ...bnkData,
+        ...pdfData,
+        raw_text: `${bnkData.raw_text}\n\n--- MERGED PDF ---\n\n${pdfData?.raw_text}`,
+    };
+
+    console.log('Combined data:', combinedData);
+
+  } else {
+    console.warn(`Could not find a BNK file and/or PDF files in ${directoryPath}`);
+  }
 };

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -4,6 +4,50 @@ import { routeFiles } from './router';
 
 const importDir = path.join(__dirname, '..', '..', '_IMPORT');
 
+const processFiles = () => {
+  fs.readdir(importDir, (err, files) => {
+    if (err) {
+      console.error(`Error reading import directory: ${err}`);
+      return;
+    }
+
+    // Group files by patient
+    const patientFolders = files.reduce((acc, file) => {
+      const patientName = path.basename(file, path.extname(file)).split('_')[0];
+      if (!acc[patientName]) {
+        acc[patientName] = [];
+      }
+      acc[patientName].push(file);
+      return acc;
+    }, {} as Record<string, string[]>);
+
+    // Process each patient's files
+    for (const patientName in patientFolders) {
+      const patientFiles = patientFolders[patientName];
+      const bnkFile = patientFiles.find(file => path.extname(file).toLowerCase() === '.bnk');
+      const pdfFiles = patientFiles.filter(file => path.extname(file).toLowerCase() === '.pdf');
+
+      if (bnkFile && pdfFiles.length > 0) {
+        // Create a subdirectory for the patient
+        const patientDir = path.join(importDir, patientName);
+        if (!fs.existsSync(patientDir)) {
+          fs.mkdirSync(patientDir, { recursive: true });
+        }
+
+        // Move the files to the subdirectory
+        patientFiles.forEach(file => {
+          const oldPath = path.join(importDir, file);
+          const newPath = path.join(patientDir, file);
+          fs.renameSync(oldPath, newPath);
+        });
+
+        // Route the files for processing
+        routeFiles(patientDir);
+      }
+    }
+  });
+};
+
 export const initializeWatcher = () => {
   // Ensure the _IMPORT directory exists
   if (!fs.existsSync(importDir)) {
@@ -12,10 +56,13 @@ export const initializeWatcher = () => {
 
   console.log(`Watching for file changes on ${importDir}`);
 
+  // Process existing files on startup
+  processFiles();
+
   fs.watch(importDir, (eventType, filename) => {
     if (filename && eventType === 'rename') {
       console.log(`File added: ${filename}`);
-      routeFiles(filename);
+      processFiles();
     }
   });
 };


### PR DESCRIPTION
This commit introduces a new parser for Boston Scientific `.bnk` files and a PDF merging utility.

- Created a new parser for Boston Scientific `.bnk` files at `src/main/parsers/boston-scientific-parser.ts`.
- Added the `pdf-lib` library for PDF manipulation.
- Implemented a PDF merging utility at `src/main/pdf-merger.ts` that includes a verification step to ensure that all merged PDFs belong to the same patient.
- Refactored the file watcher and router to group files by patient and process them as a single visit. This includes merging PDFs and combining the data from the `.bnk` file and the merged PDF.