### PR TITLE
feat: Implement robust visit grouping and unmatched file handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@types/pdf-parse": "^1.1.5",
-        "@types/uuid": "^10.0.0",
         "fast-xml-parser": "^5.3.1",
         "pdf-lib": "^1.17.1",
         "pdf-parse": "^2.4.5",
@@ -22,6 +21,7 @@
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@types/sqlite3": "^3.1.11",
+        "@types/uuid": "^10.0.0",
         "electron": "^39.0.0",
         "electron-builder": "^26.0.12",
         "sqlite3": "^5.1.7",
@@ -2106,6 +2106,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/verror": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@types/sqlite3": "^3.1.11",
+    "@types/uuid": "^10.0.0",
     "electron": "^39.0.0",
     "electron-builder": "^26.0.12",
     "sqlite3": "^5.1.7",
@@ -36,7 +37,6 @@
   },
   "dependencies": {
     "@types/pdf-parse": "^1.1.5",
-    "@types/uuid": "^10.0.0",
     "fast-xml-parser": "^5.3.1",
     "pdf-lib": "^1.17.1",
     "pdf-parse": "^2.4.5",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,8 +5,16 @@ import { initializeDatabase, getDb, getAllPatients, getPatientReports, getSettin
 import { initializeWatcher } from './watcher';
 import { seedDatabase } from './seed';
 
+let mainWindow: BrowserWindow | null;
+
+export function sendUnmatchedFiles(files: string[]) {
+  if (mainWindow) {
+    mainWindow.webContents.send('unmatched-files', files);
+  }
+}
+
 function createWindow() {
-  const mainWindow = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {

--- a/src/main/pdf-merger.ts
+++ b/src/main/pdf-merger.ts
@@ -16,17 +16,39 @@ export const extractTextFromPdf = async (filePath: string): Promise<string> => {
     return data.text;
 };
 
+import { UnifiedReport } from './reports';
+
 /**
- * Verifies that a PDF belongs to the correct patient.
+ * Verifies that a PDF's content matches the metadata from a primary report.
  *
  * @param pdfText The text extracted from the PDF.
- * @param patientFirstName The patient's first name.
- * @param patientLastName The patient's last name.
- * @returns A boolean indicating whether the PDF is verified.
+ * @param reportData The UnifiedReport object containing the metadata to verify against.
+ * @returns A boolean indicating whether the PDF content matches the report data.
  */
-export const verifyPdf = (pdfText: string, patientFirstName: string, patientLastName: string): boolean => {
-    // This is a simple verification logic. In a real scenario, this would be more robust.
-    return pdfText.includes(patientFirstName) && pdfText.includes(patientLastName);
+export const verifyPdfMatch = (pdfText: string, reportData: UnifiedReport): boolean => {
+  const { patient, interrogation_date, device } = reportData;
+
+  // Normalize all text to lowercase for case-insensitive matching
+  const lowerPdfText = pdfText.toLowerCase();
+
+  // Check for patient's first and last name
+  if (!lowerPdfText.includes(patient.first_name.toLowerCase()) || !lowerPdfText.includes(patient.last_name.toLowerCase())) {
+    return false;
+  }
+
+  // Check for the interrogation date
+  // This can be tricky due to different date formats. For now, we'll do a simple includes check.
+  // A more robust solution might involve regex and date parsing.
+  if (!lowerPdfText.includes(interrogation_date.split('T')[0])) {
+    return false;
+  }
+
+  // Check for device model and serial number
+  if (!lowerPdfText.includes(device.model.toLowerCase()) || !lowerPdfText.includes(device.serial_number.toLowerCase())) {
+    return false;
+  }
+
+  return true;
 };
 
 

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -1,62 +1,113 @@
 import fs from 'fs';
 import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { sendUnmatchedFiles } from './main';
 import { routeFiles } from './router';
+import { parseFile } from './parser';
+import { UnifiedReport } from './reports';
+import { extractTextFromPdf, verifyPdfMatch } from './pdf-merger';
 
 const importDir = path.join(__dirname, '..', '..', '_IMPORT');
+const unmatchedDir = path.join(__dirname, '..', '..', '_UNMATCHED');
 
-const processFiles = () => {
-  fs.readdir(importDir, (err, files) => {
+const processFiles = async () => {
+  fs.readdir(importDir, async (err, files) => {
     if (err) {
       console.error(`Error reading import directory: ${err}`);
       return;
     }
 
-    // Group files by patient
-    const patientFolders = files.reduce((acc, file) => {
-      const patientName = path.basename(file, path.extname(file)).split('_')[0];
-      if (!acc[patientName]) {
-        acc[patientName] = [];
-      }
-      acc[patientName].push(file);
+    const patientFileGroups = files.reduce((acc, file) => {
+      const patientId = path.basename(file, path.extname(file)).split('_')[0];
+      if (!acc[patientId]) acc[patientId] = [];
+      acc[patientId].push(file);
       return acc;
     }, {} as Record<string, string[]>);
 
-    // Process each patient's files
-    for (const patientName in patientFolders) {
-      const patientFiles = patientFolders[patientName];
-      const bnkFile = patientFiles.find(file => path.extname(file).toLowerCase() === '.bnk');
-      const pdfFiles = patientFiles.filter(file => path.extname(file).toLowerCase() === '.pdf');
+    const allUnmatchedFiles: string[] = [];
 
-      if (bnkFile && pdfFiles.length > 0) {
-        // Create a subdirectory for the patient
-        const patientDir = path.join(importDir, patientName);
-        if (!fs.existsSync(patientDir)) {
-          fs.mkdirSync(patientDir, { recursive: true });
+    for (const patientId in patientFileGroups) {
+      const patientFiles = patientFileGroups[patientId];
+      const potentialPrimaryFiles = patientFiles.filter(file => path.extname(file).toLowerCase() !== '.pdf');
+      const primaryReports: { file: string; data: UnifiedReport }[] = [];
+
+      for (const file of potentialPrimaryFiles) {
+        const reportData = await parseFile(path.join(importDir, file));
+        if (reportData) {
+          primaryReports.push({ file, data: reportData });
         }
-
-        // Move the files to the subdirectory
-        patientFiles.forEach(file => {
-          const oldPath = path.join(importDir, file);
-          const newPath = path.join(patientDir, file);
-          fs.renameSync(oldPath, newPath);
-        });
-
-        // Route the files for processing
-        routeFiles(patientDir);
       }
+      const pdfFiles = patientFiles.filter(file => path.extname(file).toLowerCase() === '.pdf');
+      const matchedFiles = new Set<string>();
+
+      if (primaryReports.length === 0) {
+        console.warn(`No primary report found for patient ${patientId}. Moving all associated files to _UNMATCHED.`);
+        for (const file of patientFiles) {
+          const oldPath = path.join(importDir, file);
+          const newPath = path.join(unmatchedDir, file);
+          fs.renameSync(oldPath, newPath);
+          allUnmatchedFiles.push(file);
+        }
+        continue;
+      }
+
+      const visits: { reportFile: string; reportData: UnifiedReport; pdfs: string[] }[] = [];
+      for (const report of primaryReports) {
+        visits.push({ reportFile: report.file, reportData: report.data, pdfs: [] });
+        matchedFiles.add(report.file);
+      }
+
+      for (const pdfFile of pdfFiles) {
+        const pdfPath = path.join(importDir, pdfFile);
+        const pdfText = await extractTextFromPdf(pdfPath);
+        for (const visit of visits) {
+          if (verifyPdfMatch(pdfText, visit.reportData)) {
+            visit.pdfs.push(pdfFile);
+            matchedFiles.add(pdfFile);
+            break;
+          }
+        }
+      }
+
+      for (const visit of visits) {
+        const visitId = `${patientId}_${visit.reportData.interrogation_date.split('T')[0]}_${uuidv4()}`;
+        const visitDir = path.join(importDir, visitId);
+        fs.mkdirSync(visitDir, { recursive: true });
+
+        const allVisitFiles = [visit.reportFile, ...visit.pdfs];
+        for (const file of allVisitFiles) {
+          const oldPath = path.join(importDir, file);
+          const newPath = path.join(visitDir, file);
+          fs.renameSync(oldPath, newPath);
+        }
+        routeFiles(visitDir);
+      }
+
+      patientFiles.forEach(file => {
+        if (!matchedFiles.has(file)) {
+          const oldPath = path.join(importDir, file);
+          const newPath = path.join(unmatchedDir, file);
+          fs.renameSync(oldPath, newPath);
+          allUnmatchedFiles.push(file);
+          console.warn(`Moved unmatched file to _UNMATCHED: ${file}`);
+        }
+      });
+    }
+
+    if (allUnmatchedFiles.length > 0) {
+      sendUnmatchedFiles(allUnmatchedFiles);
     }
   });
 };
 
 export const initializeWatcher = () => {
-  // Ensure the _IMPORT directory exists
-  if (!fs.existsSync(importDir)) {
-    fs.mkdirSync(importDir, { recursive: true });
-  }
+  [importDir, unmatchedDir].forEach(dir => {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  });
 
   console.log(`Watching for file changes on ${importDir}`);
-
-  // Process existing files on startup
   processFiles();
 
   fs.watch(importDir, (eventType, filename) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -6,4 +6,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getPdfData: (filePath: string) => ipcRenderer.invoke('get-pdf-data', filePath),
   getSettings: () => ipcRenderer.invoke('get-settings'),
   setSettings: (settings: any) => ipcRenderer.invoke('set-settings', settings),
+  onUnmatchedFiles: (callback: (files: string[]) => void) => {
+    ipcRenderer.on('unmatched-files', (event, files) => callback(files));
+  },
 });

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -3,9 +3,11 @@
   import PatientDetail from './PatientDetail.svelte';
   import Settings from './Settings.svelte';
   import { currentView } from './stores';
+  import UnmatchedFilesNotification from './UnmatchedFilesNotification.svelte';
 </script>
 
 <main>
+  <UnmatchedFilesNotification />
   <nav>
     <button on:click={() => currentView.set('dashboard')}>Dashboard</button>
     <button on:click={() => currentView.set('settings')}>Settings</button>


### PR DESCRIPTION
This change introduces a more robust system for processing files in the _IMPORT directory. It now correctly handles multiple patients and visits simultaneously by grouping files based on content analysis rather than just filenames.

Key changes include:
- The watcher now identifies primary structured reports for any manufacturer and associates PDFs with them by verifying patient data, interrogation date, and device information.
- Files that cannot be matched are moved to an _UNMATCHED' directory.
- A UI notification system has been implemented to alert users to unmatched files, ensuring they are aware of any files that require manual review.