### PR TITLE
fix(ci): use xvfb-run for e2e tests on linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/sqlite3": "^3.1.11",
         "@types/uuid": "^10.0.0",
         "cross-env": "^10.1.0",
+        "cross-os": "^1.3.0",
         "electron": "^39.0.0",
         "electron-builder": "^26.0.12",
         "sqlite3": "^5.1.7",
@@ -3341,6 +3342,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/cross-os": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cross-os/-/cross-os-1.5.0.tgz",
+      "integrity": "sha512-zjiZPGuzghQzjcymlI7oUh5iDCRlhfi9UBqkCmqxnnx/5B+K1+BgIm0YU+fua7GC+RoeywS0qsoEavRM+Kahxw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cross-os": "source/index.js"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
     "clean": "rm -rf dist",
     "test": "vitest",
     "test:e2e": "npm run build && xvfb-run --auto-servernum --server-args=\"-screen 0 1280x960x24\" -- playwright test",
-    "test:e2e:ci": "npm run build && playwright test"
+    "test:e2e:ci": "npm run build && cross-os e2e-test-runner"
+  },
+  "cross-os": {
+    "e2e-test-runner": {
+      "linux": "xvfb-run --auto-servernum --server-args=\\\"-screen 0 1280x960x24\\\" -- playwright test",
+      "win32": "playwright test",
+      "darwin": "playwright test"
+    }
   },
   "repository": {
     "type": "git",
@@ -32,6 +39,7 @@
     "@types/sqlite3": "^3.1.11",
     "@types/uuid": "^10.0.0",
     "cross-env": "^10.1.0",
+    "cross-os": "^1.3.0",
     "electron": "^39.0.0",
     "electron-builder": "^26.0.12",
     "sqlite3": "^5.1.7",


### PR DESCRIPTION
The e2e tests were failing on the Ubuntu CI runner because the Electron app could not launch without a display server.

This commit fixes the issue by using the `cross-os` package to conditionally run the e2e tests with `xvfb-run` on Linux. This provides a virtual display for the app to launch in, allowing the Playwright tests to run successfully. The tests on Windows and macOS are unaffected.