### PR TITLE
fix(ci): Correct xvfb-run argument escaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "cross-os": {
     "e2e-test-runner": {
-      "linux": "xvfb-run --auto-servernum --server-args=\\\"-screen 0 1280x960x24\\\" -- playwright test",
+      "linux": "xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' -- playwright test",
       "win32": "playwright test",
       "darwin": "playwright test"
     }


### PR DESCRIPTION
Corrected the argument escaping for the `xvfb-run` command in `package.json`. The previous implementation used escaped double quotes, which caused parsing issues in the CI environment. This has been replaced with single quotes to ensure the arguments are passed correctly.