### PR TITLE
fix(ci): Install xvfb to enable headless e2e testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install xvfb on Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
The end-to-end tests were failing in the CI environment on the Ubuntu runner with a 'Process failed to launch!' error. This was because the Electron application requires a graphical display server to run, which was not available in the headless CI environment.

This change adds a step to the CI workflow to install the `xvfb` package on the Ubuntu runner. This provides a virtual framebuffer for the application to run in, allowing the end-to-end tests to execute successfully. The `package.json` already correctly uses `xvfb-run` for the Linux environment, so no changes were needed there.