### PR TITLE
fix(ci): update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm run package
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package-${{ matrix.os }}
           path: dist/*


### PR DESCRIPTION
Updates the GitHub Actions workflow to use `actions/upload-artifact@v4` to resolve the deprecation error that was causing the build to fail.