### PR TITLE
fix(ci): ensure independent jobs and fix ubuntu tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -22,9 +23,9 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install xvfb on Linux
+      - name: Install dependencies on Linux
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb libgtk-3-0 libnss3 libasound2 libxtst6
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
This commit makes two important changes to the CI workflow:

1.  Sets `fail-fast: false` in the build matrix strategy. This ensures that a test failure on one platform (e.g., Ubuntu) will not cancel the in-progress jobs for other platforms, allowing them to build and package successfully if their own tests pass.
2.  Adds necessary system dependencies (`libgtk-3-0`, `libnss3`, `libasound2`, `libxtst6`) to the Ubuntu runner. This resolves the `Process failed to launch!` error that was causing the end-to-end tests to fail in the headless CI environment.