### PR TITLE
fix(ci): correct release publishing and dependency issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies on Linux
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y xvfb libgtk-3-0 libnss3 libasound2 libxtst6
+        run: sudo apt-get update && sudo apt-get install -y xvfb libgtk-3-0 libnss3 libasound2t64 libxtst6
 
       - name: Install dependencies
         run: npm install

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "files": [
       "dist/**/*"
     ],
-    "publish": "onTagOrDraft"
+    "publish": {
+      "provider": "github"
+    }
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",


### PR DESCRIPTION
This commit fixes two critical errors that were preventing the CI/CD pipeline from successfully publishing a GitHub Release.

1.  **Corrects the `electron-builder` publish configuration:** The `publish` property in `package.json` was changed from the invalid string `"onTagOrDraft"` to the correct object `{ "provider": "github" }`. This resolves the `unable to find publish provider` error that occurred on all platforms.
2.  **Corrects the Ubuntu dependency name:** The `libasound2` package name in `.github/workflows/ci.yml` was corrected to `libasound2t64` to match the package name in the runner's Ubuntu version, fixing the `E: Package has no installation candidate` error.