### PR TITLE
fix(watcher): resolve windows startup crash

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -50,7 +50,11 @@ app.whenReady().then(() => {
     }
   });
 
-  initializeWatcher();
+  const userDataPath = app.getPath('userData');
+  const importDir = path.join(userDataPath, '_IMPORT');
+  const unmatchedDir = path.join(userDataPath, '_UNMATCHED');
+
+  initializeWatcher(importDir, unmatchedDir);
   createWindow();
   console.log('Electron app is ready.');
 

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -7,8 +7,8 @@ import { parseFile } from './parser';
 import { UnifiedReport } from './reports';
 import { extractTextFromPdf, verifyPdfMatch } from './pdf-merger';
 
-const importDir = path.join(__dirname, '..', '..', '_IMPORT');
-const unmatchedDir = path.join(__dirname, '..', '..', '_UNMATCHED');
+let importDir: string;
+let unmatchedDir: string;
 
 /**
  * Processes files in the _IMPORT directory, grouping them by patient,
@@ -115,7 +115,9 @@ const processFiles = async () => {
 /**
  * Initializes the file watcher, which monitors the _IMPORT directory for new files.
  */
-export const initializeWatcher = () => {
+export const initializeWatcher = (appImportDir: string, appUnmatchedDir: string) => {
+  importDir = appImportDir;
+  unmatchedDir = appUnmatchedDir;
   [importDir, unmatchedDir].forEach(dir => {
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
The application was crashing on Windows during startup due to an `ENOTDIR` error. This was caused by an attempt to create the `_IMPORT` and `_UNMATCHED` directories inside the read-only `app.asar` archive.

This commit fixes the issue by relocating these directories to the user's data directory, which is a writable location.

- Modified `watcher.ts` to accept directory paths as arguments to `initializeWatcher`.
- Updated `main.ts` to use `app.getPath('userData')` to construct the paths and pass them to the watcher.