### PR TITLE
feat(watcher): add subdirectory support to file watcher

### DIFF
--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -11,103 +11,111 @@ let importDir: string;
 let unmatchedDir: string;
 
 /**
+ * Recursively gets all files in a directory.
+ * @param dir The directory to scan.
+ * @returns A list of full file paths.
+ */
+const getAllFiles = (dir: string): string[] => {
+  return fs.readdirSync(dir).reduce((files, file) => {
+    const name = path.join(dir, file);
+    const isDirectory = fs.statSync(name).isDirectory();
+    return isDirectory ? [...files, ...getAllFiles(name)] : [...files, name];
+  }, [] as string[]);
+};
+
+/**
  * Processes files in the _IMPORT directory, grouping them by patient,
  * identifying primary reports, matching them with PDFs, and creating
  * visit-specific directories.
  */
 const processFiles = async () => {
-  fs.readdir(importDir, async (err, files) => {
-    if (err) {
-      console.error(`Error reading import directory: ${err}`);
-      return;
+  const files = getAllFiles(importDir);
+  const patientFileGroups = files.reduce((acc, file) => {
+    const patientId = path.basename(file, path.extname(file)).split('_')[0];
+    if (!acc[patientId]) acc[patientId] = [];
+    acc[patientId].push(file);
+    return acc;
+  }, {} as Record<string, string[]>);
+
+  const allUnmatchedFiles: string[] = [];
+  const processedDirs = new Set<string>();
+
+  for (const patientId in patientFileGroups) {
+    const patientFiles = patientFileGroups[patientId];
+    patientFiles.forEach(file => processedDirs.add(path.dirname(file)));
+
+    const potentialPrimaryFiles = patientFiles.filter(file => path.extname(file).toLowerCase() !== '.pdf');
+    const primaryReports: { file: string; data: UnifiedReport }[] = [];
+
+    for (const file of potentialPrimaryFiles) {
+      const reportData = await parseFile(file);
+      if (reportData) {
+        primaryReports.push({ file, data: reportData });
+      }
     }
 
-    // Group files by patient ID, extracted from the filename.
-    const patientFileGroups = files.reduce((acc, file) => {
-      const patientId = path.basename(file, path.extname(file)).split('_')[0];
-      if (!acc[patientId]) acc[patientId] = [];
-      acc[patientId].push(file);
-      return acc;
-    }, {} as Record<string, string[]>);
+    const pdfFiles = patientFiles.filter(file => path.extname(file).toLowerCase() === '.pdf');
+    const matchedFiles = new Set<string>();
 
-    const allUnmatchedFiles: string[] = [];
-
-    for (const patientId in patientFileGroups) {
-      const patientFiles = patientFileGroups[patientId];
-      const potentialPrimaryFiles = patientFiles.filter(file => path.extname(file).toLowerCase() !== '.pdf');
-      const primaryReports: { file: string; data: UnifiedReport }[] = [];
-
-      // Attempt to parse all non-PDF files to find primary structured reports.
-      for (const file of potentialPrimaryFiles) {
-        const reportData = await parseFile(path.join(importDir, file));
-        if (reportData) {
-          primaryReports.push({ file, data: reportData });
-        }
+    if (primaryReports.length === 0) {
+      console.warn(`No primary report found for patient ${patientId}. Moving all associated files to _UNMATCHED.`);
+      for (const file of patientFiles) {
+        const newPath = path.join(unmatchedDir, path.basename(file));
+        fs.renameSync(file, newPath);
+        allUnmatchedFiles.push(path.basename(file));
       }
-      const pdfFiles = patientFiles.filter(file => path.extname(file).toLowerCase() === '.pdf');
-      const matchedFiles = new Set<string>();
+      continue;
+    }
 
-      // If no primary report is found, move all associated files to _UNMATCHED.
-      if (primaryReports.length === 0) {
-        console.warn(`No primary report found for patient ${patientId}. Moving all associated files to _UNMATCHED.`);
-        for (const file of patientFiles) {
-          const oldPath = path.join(importDir, file);
-          const newPath = path.join(unmatchedDir, file);
-          fs.renameSync(oldPath, newPath);
-          allUnmatchedFiles.push(file);
-        }
-        continue;
-      }
+    const visits: { reportFile: string; reportData: UnifiedReport; pdfs: string[] }[] = [];
+    for (const report of primaryReports) {
+      visits.push({ reportFile: report.file, reportData: report.data, pdfs: [] });
+      matchedFiles.add(report.file);
+    }
 
-      // Create visits for each primary report and match associated PDFs.
-      const visits: { reportFile: string; reportData: UnifiedReport; pdfs: string[] }[] = [];
-      for (const report of primaryReports) {
-        visits.push({ reportFile: report.file, reportData: report.data, pdfs: [] });
-        matchedFiles.add(report.file);
-      }
-
-      for (const pdfFile of pdfFiles) {
-        const pdfPath = path.join(importDir, pdfFile);
-        const pdfText = await extractTextFromPdf(pdfPath);
-        for (const visit of visits) {
-          if (verifyPdfMatch(pdfText, visit.reportData)) {
-            visit.pdfs.push(pdfFile);
-            matchedFiles.add(pdfFile);
-            break;
-          }
-        }
-      }
-
-      // Create a unique directory for each visit and move all associated files into it.
+    for (const pdfFile of pdfFiles) {
+      const pdfText = await extractTextFromPdf(pdfFile);
       for (const visit of visits) {
-        const visitId = `${patientId}_${visit.reportData.interrogation_date.split('T')[0]}_${uuidv4()}`;
-        const visitDir = path.join(importDir, visitId);
-        fs.mkdirSync(visitDir, { recursive: true });
-
-        const allVisitFiles = [visit.reportFile, ...visit.pdfs];
-        for (const file of allVisitFiles) {
-          const oldPath = path.join(importDir, file);
-          const newPath = path.join(visitDir, file);
-          fs.renameSync(oldPath, newPath);
+        if (verifyPdfMatch(pdfText, visit.reportData)) {
+          visit.pdfs.push(pdfFile);
+          matchedFiles.add(pdfFile);
+          break;
         }
-        routeFiles(visitDir);
       }
-
-      // Move any remaining unmatched files to the _UNMATCHED directory.
-      patientFiles.forEach(file => {
-        if (!matchedFiles.has(file)) {
-          const oldPath = path.join(importDir, file);
-          const newPath = path.join(unmatchedDir, file);
-          fs.renameSync(oldPath, newPath);
-          allUnmatchedFiles.push(file);
-          console.warn(`Moved unmatched file to _UNMATCHED: ${file}`);
-        }
-      });
     }
 
-    // Notify the renderer process of any unmatched files.
-    if (allUnmatchedFiles.length > 0) {
-      sendUnmatchedFiles(allUnmatchedFiles);
+    for (const visit of visits) {
+      const visitId = `${patientId}_${visit.reportData.interrogation_date.split('T')[0]}_${uuidv4()}`;
+      const visitDir = path.join(importDir, visitId);
+      fs.mkdirSync(visitDir, { recursive: true });
+
+      const allVisitFiles = [visit.reportFile, ...visit.pdfs];
+      for (const file of allVisitFiles) {
+        const newPath = path.join(visitDir, path.basename(file));
+        fs.renameSync(file, newPath);
+      }
+      routeFiles(visitDir);
+    }
+
+    patientFiles.forEach(file => {
+      if (!matchedFiles.has(file)) {
+        const newPath = path.join(unmatchedDir, path.basename(file));
+        fs.renameSync(file, newPath);
+        allUnmatchedFiles.push(path.basename(file));
+        console.warn(`Moved unmatched file to _UNMATCHED: ${path.basename(file)}`);
+      }
+    });
+  }
+
+  if (allUnmatchedFiles.length > 0) {
+    sendUnmatchedFiles(allUnmatchedFiles);
+  }
+
+  // Clean up empty directories
+  processedDirs.forEach(dir => {
+    if (fs.readdirSync(dir).length === 0 && dir !== importDir) {
+      fs.rmdirSync(dir);
+      console.log(`Removed empty directory: ${dir}`);
     }
   });
 };
@@ -127,7 +135,7 @@ export const initializeWatcher = (appImportDir: string, appUnmatchedDir: string)
   console.log(`Watching for file changes on ${importDir}`);
   processFiles();
 
-  fs.watch(importDir, (eventType, filename) => {
+  fs.watch(importDir, { recursive: true }, (eventType, filename) => {
     if (filename && eventType === 'rename') {
       console.log(`File added: ${filename}`);
       processFiles();


### PR DESCRIPTION
- Implement recursive file searching to process files in subdirectories
- Update file grouping and processing logic to use full file paths
- Add cleanup step to remove empty directories after processing
- Fix EPERM error caused by attempting to move a directory