### PR TITLE
feat: Arrange viewer slots horizontally

### DIFF
--- a/src/renderer/PatientDetail.tsx
+++ b/src/renderer/PatientDetail.tsx
@@ -65,7 +65,7 @@ const PatientDetail: React.FC = () => {
   return (
     <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <div className="flex h-full space-x-4">
-        <div className="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="flex-1 flex gap-4">
           {viewerSlots.map((slot, i) => (
             <Droppable key={`slot-${i}`} id={`slot-${i}`}>
               <Card className="h-full">


### PR DESCRIPTION
Changed the layout of the viewer slots in the PatientDetail component from a grid to a flexbox layout. This arranges the three viewer slots horizontally next to each other, instead of vertically stacking them.