### PR TITLE
fix(build): Standardize camelCase in data models

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -145,12 +145,12 @@ export const getPatientReports = (patientId: string): Promise<any[]> => {
           id: row.id,
           manufacturer: row.manufacturer,
           interrogation_date: row.interrogation_date,
-          hospital_visit_id: row.hospitalVisitId,
+          hospitalVisitId: row.hospitalVisitId,
           patient: {
             first_name: row.first_name,
             last_name: row.last_name,
             dob: row.dob,
-            hospital_patient_id: row.hospitalPatientId,
+            hospitalPatientId: row.hospitalPatientId,
           },
           device: {
             type: row.device_type,

--- a/src/main/reports.ts
+++ b/src/main/reports.ts
@@ -36,14 +36,14 @@ export interface UnifiedReport {
   // --- Metadata (from the report and the hospital system) ---
   manufacturer: 'Medtronic' | 'Biotronik' | 'Abbott' | 'Boston Scientific' | 'Impulse Dynamics' | 'Microport' | 'Unknown' | string;
   interrogation_date: string; // ISO 8601 format
-  hospital_visit_id?: string; // ADDED: The hospital's identifier for this specific visit/encounter.
+  hospitalVisitId?: string; // ADDED: The hospital's identifier for this specific visit/encounter.
 
   // --- Patient Identification ---
   patient: {
     first_name: string; // ADDED: More granular name fields
     last_name: string;  // ADDED
     dob: string;        // RENAMED for clarity (Date of Birth in ISO 8601 format)
-    hospital_patient_id?: string; // ADDED: The patient's permanent ID in the hospital system (e.g., MRN)
+    hospitalPatientId?: string; // ADDED: The patient's permanent ID in the hospital system (e.g., MRN)
   };
 
   // --- Device & System Identification ---


### PR DESCRIPTION
Resolves TypeScript build errors by standardizing on camelCase for properties in the UnifiedReport interface and ensuring consistency across the database and storage layers.

This fixes a naming mismatch (snake_case vs. camelCase) between the TypeScript types and the database access code, which was causing the build to fail with TS2551 errors.