### PR TITLE
refactor: resolve circular dependency in main process

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,23 +6,10 @@ import { initializeWatcher } from './watcher';
 import { seedDatabase } from './seed';
 import { getConfig, saveConfig } from './config';
 import { initializeStorage } from './storage';
-
-let mainWindow: BrowserWindow | null;
-
-export function sendUnmatchedFiles(files: string[]) {
-  if (mainWindow) {
-    mainWindow.webContents.send('unmatched-files', files);
-  }
-}
-
-export function sendNotification(message: string, type: 'info' | 'warning' | 'error' = 'info') {
-  if (mainWindow) {
-    mainWindow.webContents.send('notify', { type, message });
-  }
-}
+import { setMainWindow, getMainWindow } from './windowManager';
 
 function createWindow() {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
@@ -38,6 +25,8 @@ function createWindow() {
   } else {
     mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
   }
+
+  setMainWindow(mainWindow);
 }
 
 app.whenReady().then(async () => {
@@ -91,6 +80,7 @@ ipcMain.handle('get-all-patients', async (event, filters) => {
 });
 
 ipcMain.handle('select-directory', async () => {
+  const mainWindow = getMainWindow();
   if (!mainWindow) {
     return;
   }

--- a/src/main/storage.ts
+++ b/src/main/storage.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { findPatient, createPatient, createReport, getSettings } from './database';
 import { UnifiedReport } from './reports';
 import { app } from 'electron';
-import { sendNotification } from './main';
+import { sendNotification } from './windowManager';
 
 let dataDir: string;
 

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
-import { sendUnmatchedFiles, sendNotification } from './main';
+import { sendUnmatchedFiles, sendNotification } from './windowManager';
 import { parseFile } from './parser';
 import { UnifiedReport } from './reports';
 import { getDb } from './database';

--- a/src/main/windowManager.ts
+++ b/src/main/windowManager.ts
@@ -1,0 +1,23 @@
+import { BrowserWindow } from 'electron';
+
+let mainWindow: BrowserWindow | null;
+
+export function setMainWindow(window: BrowserWindow) {
+  mainWindow = window;
+}
+
+export function getMainWindow(): BrowserWindow | null {
+  return mainWindow;
+}
+
+export function sendUnmatchedFiles(files: string[]) {
+  if (mainWindow) {
+    mainWindow.webContents.send('unmatched-files', files);
+  }
+}
+
+export function sendNotification(message: string, type: 'info' | 'warning' | 'error' = 'info') {
+  if (mainWindow) {
+    mainWindow.webContents.send('notify', { type, message });
+  }
+}


### PR DESCRIPTION
Extracted window management logic into a new `src/main/windowManager.ts` file to resolve a circular dependency between `main.ts`, `watcher.ts`, and `storage.ts`.

- `main.ts` now imports `setMainWindow` and `getMainWindow` from `windowManager.ts`.
- `watcher.ts` and `storage.ts` now import `sendNotification` and `sendUnmatchedFiles` from `windowManager.ts`.